### PR TITLE
Transpose recent B0 fixes to B+ workflow + update standard workflows

### DIFF
--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -209,6 +209,29 @@ DECLARE_SOA_TABLE(HfRed3ProngsCov, "AOD", "HFRED3PRONGSCOV", //! Table with 3pro
                   HFTRACKPARCOV_COLUMNS,
                   o2::soa::Marker<2>);
 
+// Beauty candidates prongs
+namespace hf_cand_b0_reduced
+{
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong0, prong0, int, HfRed3Prongs, "_0");    //! Prong0 index
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong1, prong1, int, HfRedTrackBases, "_1"); //! Prong1 index
+} // namespace hf_cand_b0_reduced
+
+DECLARE_SOA_TABLE(HfRedB0Prongs, "AOD", "HFREDB0PRONG",
+                  hf_cand_b0_reduced::Prong0Id, hf_cand_b0_reduced::Prong1Id);
+
+using HfRedCandB0 = soa::Join<HfCandB0Ext, HfRedB0Prongs>;
+
+namespace hf_cand_bplus_reduced
+{
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong0, prong0, int, HfRed2Prongs, "_0");    //! Prong0 index
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong1, prong1, int, HfRedTrackBases, "_1"); //! Prong1 index
+} // namespace hf_cand_bplus_reduced
+
+DECLARE_SOA_TABLE(HfRedBplusProngs, "AOD", "HFREDBPPRONG",
+                  hf_cand_bplus_reduced::Prong0Id, hf_cand_bplus_reduced::Prong1Id);
+
+using HfRedCandBplus = soa::Join<HfCandBplusExt, HfRedBplusProngs>;
+
 namespace hf_b0_mc
 {
 // MC Rec
@@ -225,16 +248,6 @@ DECLARE_SOA_COLUMN(YProng1, yProng1, float);     //! Rapidity of the track's pro
 DECLARE_SOA_COLUMN(EtaProng1, etaProng1, float); //! Pseudorapidity of the track's prong1
 } // namespace hf_b0_mc
 
-namespace hf_cand_b0_reduced
-{
-DECLARE_SOA_INDEX_COLUMN_FULL(Prong0, prong0, int, HfRed3Prongs, "_0");    //! Prong0 index
-DECLARE_SOA_INDEX_COLUMN_FULL(Prong1, prong1, int, HfRedTrackBases, "_1"); //! Prong1 index
-} // namespace hf_cand_b0_reduced
-
-DECLARE_SOA_TABLE(HfRedB0Prongs, "AOD", "HFREDB0PRONG",
-                  hf_cand_b0_reduced::Prong0Id, hf_cand_b0_reduced::Prong1Id);
-
-using HfRedCandB0 = soa::Join<HfCandB0Ext, HfRedB0Prongs>;
 
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfMcRecRedDpPis, "AOD", "HFMCRECREDDPPI", //! Table with reconstructed MC information on DPi(<-B0) pairs for reduced workflow
@@ -292,8 +305,8 @@ DECLARE_SOA_COLUMN(EtaProng1, etaProng1, float); //! Pseudorapidity of the track
 
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfMcRecRedD0Pis, "AOD", "HFMCRECREDD0PI", //! Table with reconstructed MC information on D0Pi(<-B+) pairs for reduced workflow
-                  hf_cand_bplus::Prong0Id,
-                  hf_track_index::Prong1Id,
+                  hf_cand_bplus_reduced::Prong0Id,
+                  hf_cand_bplus_reduced::Prong1Id,
                   hf_cand_bplus::FlagMcMatchRec,
                   hf_bplus_mc::PtMother);
 
@@ -320,11 +333,13 @@ namespace hf_cand_bplus_config
 {
 DECLARE_SOA_COLUMN(MySelectionFlagD0, mySelectionFlagD0, int8_t);       //! Flag to filter selected D0 mesons
 DECLARE_SOA_COLUMN(MySelectionFlagD0bar, mySelectionFlagD0bar, int8_t); //! Flag to filter selected D0 mesons
+DECLARE_SOA_COLUMN(MyInvMassWindowD0Pi, myInvMassWindowD0Pi, float);    //! Half-width of the Bplus invariant-mass window in GeV/c2
 } // namespace hf_cand_bplus_config
 
 DECLARE_SOA_TABLE(HfCandBpConfigs, "AOD", "HFCANDBPCONFIG", //! Table with configurables information for reduced workflow
                   hf_cand_bplus_config::MySelectionFlagD0,
-                  hf_cand_bplus_config::MySelectionFlagD0bar);
+                  hf_cand_bplus_config::MySelectionFlagD0bar,
+                  hf_cand_bplus_config::MyInvMassWindowD0Pi);
 } // namespace aod
 
 namespace soa

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -141,16 +141,8 @@ DECLARE_SOA_TABLE(HfRedTracksPid, "AOD", "HFREDTRACKPID", //! Table with PID tra
                   o2::soa::Index<>,
                   hf_track_index_reduced::HasTPC,
                   hf_track_index_reduced::HasTOF,
-                  pidtpc::TPCNSigmaEl,
-                  pidtpc::TPCNSigmaMu,
                   pidtpc::TPCNSigmaPi,
-                  pidtpc::TPCNSigmaKa,
-                  pidtpc::TPCNSigmaPr,
-                  pidtof::TOFNSigmaEl,
-                  pidtof::TOFNSigmaMu,
-                  pidtof::TOFNSigmaPi,
-                  pidtof::TOFNSigmaKa,
-                  pidtof::TOFNSigmaPr);
+                  pidtof::TOFNSigmaPi);
 
 DECLARE_SOA_EXTENDED_TABLE_USER(HfRedTracksExt, HfRedTrackBases, "HFREDTRACKEXT", //! Track parameters at collision vertex
                                 aod::track::Pt);

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -248,7 +248,6 @@ DECLARE_SOA_COLUMN(YProng1, yProng1, float);     //! Rapidity of the track's pro
 DECLARE_SOA_COLUMN(EtaProng1, etaProng1, float); //! Pseudorapidity of the track's prong1
 } // namespace hf_b0_mc
 
-
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfMcRecRedDpPis, "AOD", "HFMCRECREDDPPI", //! Table with reconstructed MC information on DPi(<-B0) pairs for reduced workflow
                   hf_cand_b0_reduced::Prong0Id,

--- a/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
@@ -47,7 +47,7 @@ struct HfCandidateCreatorB0Reduced {
   Configurable<double> minRelChi2Change{"minRelChi2Change", 0.9, "stop iterations is chi2/chi2old > this"};
   // selection
   Configurable<double> invMassWindowDPiTolerance{"invMassWindowDPiTolerance", 0.01, "invariant-mass window tolerance for DPi pair preselections (GeV/c2)"};
-  // variable that will store the value of invMassWindowB0 (defined in dataCreatorDplusPiReduced.cxx)
+  // variable that will store the value of invMassWindowDPi (defined in dataCreatorDplusPiReduced.cxx)
   float myInvMassWindowDPi{1.};
 
   // O2DatabasePDG service
@@ -57,8 +57,6 @@ struct HfCandidateCreatorB0Reduced {
   double massD{0.};
   double massB0{0.};
   double invMass2DPi{0.};
-  double invMass2DPiMin{0.};
-  double invMass2DPiMax{0.};
   double bz{0.};
 
   // Fitter for B vertex (2-prong vertex filter)
@@ -98,14 +96,14 @@ struct HfCandidateCreatorB0Reduced {
                aod::HfOrigColCounts const& collisionsCounter,
                aod::HfCandB0Configs const& configs)
   {
-    // B0 invariant-mass window cut
+    // DPi invariant-mass window cut
     for (const auto& config : configs) {
       myInvMassWindowDPi = config.myInvMassWindowDPi();
     }
     // invMassWindowDPiTolerance is used to apply a slightly tighter cut than in DPi pair preselection
     // to avoid accepting DPi pairs that were not formed in DPi pair creator
-    invMass2DPiMin = (massB0 - myInvMassWindowDPi + invMassWindowDPiTolerance) * (massB0 - myInvMassWindowDPi + invMassWindowDPiTolerance);
-    invMass2DPiMax = (massB0 + myInvMassWindowDPi - invMassWindowDPiTolerance) * (massB0 + myInvMassWindowDPi - invMassWindowDPiTolerance);
+    double invMass2DPiMin = (massB0 - myInvMassWindowDPi + invMassWindowDPiTolerance) * (massB0 - myInvMassWindowDPi + invMassWindowDPiTolerance);
+    double invMass2DPiMax = (massB0 + myInvMassWindowDPi - invMassWindowDPiTolerance) * (massB0 + myInvMassWindowDPi - invMassWindowDPiTolerance);
 
     for (const auto& collisionCounter : collisionsCounter) {
       registry.fill(HIST("hEvents"), 1, collisionCounter.originalCollisionCount());
@@ -142,7 +140,7 @@ struct HfCandidateCreatorB0Reduced {
           auto trackParCovPi = getTrackParCov(trackPion);
           std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
 
-          // compute invariant
+          // compute invariant mass square and apply selection
           invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
           if ((invMass2DPi < invMass2DPiMin) || (invMass2DPi > invMass2DPiMax)) {
             continue;

--- a/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
@@ -56,7 +56,6 @@ struct HfCandidateCreatorB0Reduced {
   double massPi{0.};
   double massD{0.};
   double massB0{0.};
-  double invMass2DPi{0.};
   double bz{0.};
 
   // Fitter for B vertex (2-prong vertex filter)
@@ -70,7 +69,7 @@ struct HfCandidateCreatorB0Reduced {
   void init(InitContext const&)
   {
     // histograms
-    registry.add("hMass2B0ToDPi", "2-prong candidates;inv. mass (B^{0} #rightarrow D^{#minus}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#minus}#pi^{#plus}) square (GeV^{2}/#it{c}^{4});entries", {HistType::kTH1F, {{500, 3., 8.}}});
+    registry.add("hMassB0ToDPi", "2-prong candidates;inv. mass (B^{0} #rightarrow D^{#minus}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#minus}#pi^{#plus}) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 3., 8.}}});
     registry.add("hCovPVXX", "2-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}});
     registry.add("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
     registry.add("hEvents", "Events;;entries", HistType::kTH1F, {{1, 0.5, 1.5}});
@@ -141,7 +140,7 @@ struct HfCandidateCreatorB0Reduced {
           std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
 
           // compute invariant mass square and apply selection
-          invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
+          auto invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
           if ((invMass2DPi < invMass2DPiMin) || (invMass2DPi > invMass2DPiMax)) {
             continue;
           }
@@ -165,7 +164,7 @@ struct HfCandidateCreatorB0Reduced {
           df2.getTrack(0).getPxPyPzGlo(pVecD);    // momentum of D at the B0 vertex
           df2.getTrack(1).getPxPyPzGlo(pVecPion); // momentum of Pi at the B0 vertex
 
-          registry.fill(HIST("hMass2B0ToDPi"), invMass2DPi);
+          registry.fill(HIST("hMassB0ToDPi"), std::sqrt(invMass2DPi));
 
           // compute impact parameters of D and Pi
           o2::dataformats::DCA dcaD;

--- a/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
@@ -16,6 +16,7 @@
 
 #include "DCAFitter/DCAFitterN.h"
 #include "Framework/AnalysisTask.h"
+#include "Framework/O2DatabasePDGPlugin.h"
 #include "Framework/runDataProcessing.h"
 #include "ReconstructionDataFormats/DCA.h"
 #include "ReconstructionDataFormats/V0.h"
@@ -35,6 +36,7 @@ using namespace o2::framework::expressions;
 /// Reconstruction of B+ candidates
 struct HfCandidateCreatorBplusReduced {
   Produces<aod::HfCandBplusBase> rowCandidateBase; // table defined in CandidateReconstructionTables.h
+  Produces<aod::HfRedBplusProngs> rowCandidateProngs; // table defined in ReducedDataModel.h
 
   // vertexing
   Configurable<bool> propagateToPCA{"propagateToPCA", true, "create tracks version propagated to PCA"};
@@ -45,12 +47,17 @@ struct HfCandidateCreatorBplusReduced {
   Configurable<double> minParamChange{"minParamChange", 1.e-3, "stop iterations if largest change of any B+ is smaller than this"};
   Configurable<double> minRelChi2Change{"minRelChi2Change", 0.9, "stop iterations is chi2/chi2old > this"};
   // selection
-  Configurable<double> invMassWindowBplus{"invMassWindowBplus", 0.3, "invariant-mass window for B+ candidates"};
+  Configurable<double> invMassWindowD0PiTolerance{"invMassWindowD0PiTolerance", 0.01, "invariant-mass window tolerance for D0Pi pair preselections (GeV/c2)"};
+  // variable that will store the value of invMassWindowD0Pi (defined in dataCreatorD0PiReduced.cxx)
+  float myInvMassWindowD0Pi{1.};
 
-  double massPi = RecoDecay::getMassPDG(kPiPlus);
-  double massD0 = RecoDecay::getMassPDG(pdg::Code::kD0);
-  double massBplus = RecoDecay::getMassPDG(pdg::Code::kBPlus);
-  double massD0Pi{0.};
+  // O2DatabasePDG service
+  Service<o2::framework::O2DatabasePDG> pdg;
+
+  double massPi{0.};
+  double massD0{0.};
+  double massBplus{0.};
+  double invMass2D0Pi{0.};
   double bz{0.};
 
   // Fitter for B vertex (2-prong vertex filter)
@@ -64,7 +71,7 @@ struct HfCandidateCreatorBplusReduced {
   void init(InitContext const&)
   {
     // histograms
-    registry.add("hMassBplusToD0Pi", "2-prong candidates;inv. mass (B^{+} #rightarrow #overline{D^{0}}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#plus}) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 3., 8.}}});
+    registry.add("hMass2BplusToD0Pi", "2-prong candidates;inv. mass (B^{+} #rightarrow #overline{D^{0}}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#plus}) square (GeV^{2}/#it{c}^{4});entries", {HistType::kTH1F, {{500, 3., 8.}}});
     registry.add("hCovPVXX", "2-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}});
     registry.add("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
     registry.add("hEvents", "Events;;entries", HistType::kTH1F, {{1, 0.5, 1.5}});
@@ -77,13 +84,28 @@ struct HfCandidateCreatorBplusReduced {
     df2.setMinRelChi2Change(minRelChi2Change);
     df2.setUseAbsDCA(useAbsDCA);
     df2.setWeightedFinalPCA(useWeightedFinalPCA);
+
+    // invariant-mass window cut
+    massPi = pdg->Mass(kPiPlus);
+    massD0 = pdg->Mass(pdg::Code::kD0);
+    massBplus = pdg->Mass(pdg::Code::kBPlus);
   }
 
   void process(aod::HfRedCollisions const& collisions,
                soa::Join<aod::HfRed2Prongs, aod::HfRed2ProngsCov> const& candsD,
-               soa::Join<aod::HfRedTracks, aod::HfRedTracksCov> const& tracksPion,
-               aod::HfOrigColCounts const& collisionsCounter)
+               soa::Join<aod::HfRedTrackBases, aod::HfRedTracksCov> const& tracksPion,
+               aod::HfOrigColCounts const& collisionsCounter,
+               aod::HfCandBpConfigs const& configs)
   {
+    // D0Pi invariant-mass window cut
+    for (const auto& config : configs) {
+      myInvMassWindowD0Pi = config.myInvMassWindowD0Pi();
+    }
+    // invMassWindowD0PiTolerance is used to apply a slightly tighter cut than in D0Pi pair preselection
+    // to avoid accepting D0Pi pairs that were not formed in D0Pi pair creator
+    double invMass2D0PiMin = (massBplus - myInvMassWindowD0Pi + invMassWindowD0PiTolerance) * (massBplus - myInvMassWindowD0Pi + invMassWindowD0PiTolerance);
+    double invMass2D0PiMax = (massBplus + myInvMassWindowD0Pi - invMassWindowD0PiTolerance) * (massBplus + myInvMassWindowD0Pi - invMassWindowD0PiTolerance);
+
     for (const auto& collisionCounter : collisionsCounter) {
       registry.fill(HIST("hEvents"), 1, collisionCounter.originalCollisionCount());
     }
@@ -114,6 +136,11 @@ struct HfCandidateCreatorBplusReduced {
           auto trackParCovPi = getTrackParCov(trackPion);
           std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
 
+          // compute invariant mass square and apply selection
+          invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecPion}, std::array{massD0, massPi});
+          if ((invMass2D0Pi < invMass2D0PiMin) || (invMass2D0Pi > invMass2D0PiMax)) {
+            continue;
+          }
           // ---------------------------------
           // reconstruct the 2-prong B+ vertex
           if (df2.process(trackParCovD, trackParCovPi) == 0) {
@@ -134,13 +161,7 @@ struct HfCandidateCreatorBplusReduced {
           df2.getTrack(0).getPxPyPzGlo(pVecD0);   // momentum of D0 at the B+ vertex
           df2.getTrack(1).getPxPyPzGlo(pVecPion); // momentum of Pi at the B+ vertex
 
-          // compute invariant
-          massD0Pi = RecoDecay::m(std::array{pVecD0, pVecPion}, std::array{massD0, massPi});
-
-          if (std::abs(massD0Pi - massBplus) > invMassWindowBplus) {
-            continue;
-          }
-          registry.fill(HIST("hMassBplusToD0Pi"), massD0Pi);
+          registry.fill(HIST("hMass2BplusToD0Pi"), invMass2D0Pi);
 
           // compute impact parameters of D0 and Pi
           o2::dataformats::DCA dcaD0;
@@ -167,8 +188,9 @@ struct HfCandidateCreatorBplusReduced {
                            pVecPion[0], pVecPion[1], pVecPion[2],
                            dcaD0.getY(), dcaPion.getY(),
                            std::sqrt(dcaD0.getSigmaY2()), std::sqrt(dcaPion.getSigmaY2()),
-                           candD0.globalIndex(), trackPion.globalIndex(),
                            hfFlag);
+
+          rowCandidateProngs(candD0.globalIndex(), trackPion.globalIndex());
         } // pi loop
       }   // D0 loop
     }     // collision loop
@@ -178,11 +200,12 @@ struct HfCandidateCreatorBplusReduced {
 /// Extends the table base with expression columns and performs MC matching.
 struct HfCandidateCreatorBplusReducedExpressions {
   Spawns<aod::HfCandBplusExt> rowCandidateBPlus;
+  Spawns<aod::HfRedTracksExt> rowTracksExt;
   Produces<aod::HfMcRecRedBps> rowBplusMcRec;
 
-  void processMc(HfMcRecRedD0Pis const& rowsD0PiMcRec)
+  void processMc(HfMcRecRedD0Pis const& rowsD0PiMcRec, HfRedBplusProngs const& candsBplus)
   {
-    for (const auto& candBplus : *rowCandidateBPlus) {
+    for (const auto& candBplus : candsBplus) {
       for (const auto& rowD0PiMcRec : rowsD0PiMcRec) {
         if ((rowD0PiMcRec.prong0Id() != candBplus.prong0Id()) || (rowD0PiMcRec.prong1Id() != candBplus.prong1Id())) {
           continue;

--- a/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
@@ -57,7 +57,6 @@ struct HfCandidateCreatorBplusReduced {
   double massPi{0.};
   double massD0{0.};
   double massBplus{0.};
-  double invMass2D0Pi{0.};
   double bz{0.};
 
   // Fitter for B vertex (2-prong vertex filter)
@@ -71,7 +70,7 @@ struct HfCandidateCreatorBplusReduced {
   void init(InitContext const&)
   {
     // histograms
-    registry.add("hMass2BplusToD0Pi", "2-prong candidates;inv. mass (B^{+} #rightarrow #overline{D^{0}}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#plus}) square (GeV^{2}/#it{c}^{4});entries", {HistType::kTH1F, {{500, 3., 8.}}});
+    registry.add("hMassBplusToD0Pi", "2-prong candidates;inv. mass (B^{+} #rightarrow #overline{D^{0}}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#plus}) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 3., 8.}}});
     registry.add("hCovPVXX", "2-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}});
     registry.add("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
     registry.add("hEvents", "Events;;entries", HistType::kTH1F, {{1, 0.5, 1.5}});
@@ -137,7 +136,7 @@ struct HfCandidateCreatorBplusReduced {
           std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
 
           // compute invariant mass square and apply selection
-          invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecPion}, std::array{massD0, massPi});
+          auto invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecPion}, std::array{massD0, massPi});
           if ((invMass2D0Pi < invMass2D0PiMin) || (invMass2D0Pi > invMass2D0PiMax)) {
             continue;
           }
@@ -161,7 +160,7 @@ struct HfCandidateCreatorBplusReduced {
           df2.getTrack(0).getPxPyPzGlo(pVecD0);   // momentum of D0 at the B+ vertex
           df2.getTrack(1).getPxPyPzGlo(pVecPion); // momentum of Pi at the B+ vertex
 
-          registry.fill(HIST("hMass2BplusToD0Pi"), invMass2D0Pi);
+          registry.fill(HIST("hMassBplusToD0Pi"), std::sqrt(invMass2D0Pi));
 
           // compute impact parameters of D0 and Pi
           o2::dataformats::DCA dcaD0;

--- a/PWGHF/D2H/TableProducer/candidateSelectorBplusToD0PiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateSelectorBplusToD0PiReduced.cxx
@@ -91,7 +91,7 @@ struct HfCandidateSelectorBplusToD0PiReduced {
     }
   }
 
-  void process(HfCandBplus const& hfCandBs,
+  void process(HfRedCandBplus const& hfCandBs,
                HfRed2Prongs const&,
                TracksPion const&,
                HfCandBpConfigs const& configs)

--- a/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
@@ -95,7 +95,6 @@ struct HfDataCreatorD0PiReduced {
   double massPi{0.};
   double massD0{0.};
   double massBplus{0.};
-  double invMass2D0Pi{0.};
   double invMass2D0PiMin{0.};
   double invMass2D0PiMax{0.};
   double bz{0.};
@@ -317,7 +316,7 @@ struct HfDataCreatorD0PiReduced {
           registry.fill(HIST("hPtPion"), trackPion.pt());
           std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
           // compute invariant mass square and apply selection
-          invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecPion}, std::array{massD0, massPi});
+          auto invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecPion}, std::array{massD0, massPi});
           if ((invMass2D0Pi < invMass2D0PiMin) || (invMass2D0Pi > invMass2D0PiMax)) {
             continue;
           }
@@ -336,8 +335,7 @@ struct HfDataCreatorD0PiReduced {
                            trackPion.c1PtY(), trackPion.c1PtZ(), trackPion.c1PtSnp(),
                            trackPion.c1PtTgl(), trackPion.c1Pt21Pt2());
             hfTrackPidPion(trackPion.hasTPC(), trackPion.hasTOF(),
-                           trackPion.tpcNSigmaEl(), trackPion.tpcNSigmaMu(), trackPion.tpcNSigmaPi(), trackPion.tpcNSigmaKa(), trackPion.tpcNSigmaPr(),
-                           trackPion.tofNSigmaEl(), trackPion.tofNSigmaMu(), trackPion.tofNSigmaPi(), trackPion.tofNSigmaKa(), trackPion.tofNSigmaPr());
+                           trackPion.tpcNSigmaPi(), trackPion.tofNSigmaPi());
             // add trackPion.globalIndex() to a list
             // to keep memory of the pions filled in the table and avoid refilling them if they are paired to another D candidate
             // and keep track of their index in hfTrackPion for McRec purposes

--- a/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
@@ -441,10 +441,10 @@ struct HfDataCreatorD0PiReduced {
   }
 
   void processData(aod::Collisions const& collisions,
-               CandsDFiltered const& candsD0,
-               aod::TrackAssoc const& trackIndices,
-               TracksPIDWithSel const& tracks,
-               aod::BCsWithTimestamps const& bcs)
+                   CandsDFiltered const& candsD0,
+                   aod::TrackAssoc const& trackIndices,
+                   TracksPIDWithSel const& tracks,
+                   aod::BCsWithTimestamps const& bcs)
   {
     runDataCreation<false>(collisions, candsD0, trackIndices, tracks, tracks, bcs);
   }

--- a/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
@@ -94,7 +94,6 @@ struct HfDataCreatorDplusPiReduced {
   double massPi{0.};
   double massD{0.};
   double massB0{0.};
-  double invMassD{0.};
   double invMass2DPi{0.};
   double invMass2DPiMin{0.};
   double invMass2DPiMax{0.};
@@ -320,7 +319,7 @@ struct HfDataCreatorDplusPiReduced {
           }
           registry.fill(HIST("hPtPion"), trackPion.pt());
           std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
-          // compute invariant mass and apply selection
+          // compute invariant mass square and apply selection
           invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
           if ((invMass2DPi < invMass2DPiMin) || (invMass2DPi > invMass2DPiMax)) {
             continue;

--- a/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
@@ -94,7 +94,6 @@ struct HfDataCreatorDplusPiReduced {
   double massPi{0.};
   double massD{0.};
   double massB0{0.};
-  double invMass2DPi{0.};
   double invMass2DPiMin{0.};
   double invMass2DPiMax{0.};
   double bz{0.};
@@ -320,7 +319,7 @@ struct HfDataCreatorDplusPiReduced {
           registry.fill(HIST("hPtPion"), trackPion.pt());
           std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
           // compute invariant mass square and apply selection
-          invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
+          auto invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
           if ((invMass2DPi < invMass2DPiMin) || (invMass2DPi > invMass2DPiMax)) {
             continue;
           }
@@ -339,8 +338,7 @@ struct HfDataCreatorDplusPiReduced {
                            trackPion.c1PtY(), trackPion.c1PtZ(), trackPion.c1PtSnp(),
                            trackPion.c1PtTgl(), trackPion.c1Pt21Pt2());
             hfTrackPidPion(trackPion.hasTPC(), trackPion.hasTOF(),
-                           trackPion.tpcNSigmaEl(), trackPion.tpcNSigmaMu(), trackPion.tpcNSigmaPi(), trackPion.tpcNSigmaKa(), trackPion.tpcNSigmaPr(),
-                           trackPion.tofNSigmaEl(), trackPion.tofNSigmaMu(), trackPion.tofNSigmaPi(), trackPion.tofNSigmaKa(), trackPion.tofNSigmaPr());
+                           trackPion.tpcNSigmaPi(), trackPion.tofNSigmaPi());
             // add trackPion.globalIndex() to a list
             // to keep memory of the pions filled in the table and avoid refilling them if they are paired to another D candidate
             // and keep track of their index in hfTrackPion for McRec purposes

--- a/PWGHF/D2H/Tasks/taskB0.cxx
+++ b/PWGHF/D2H/Tasks/taskB0.cxx
@@ -16,6 +16,7 @@
 
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
+#include "Framework/O2DatabasePDGPlugin.h"
 #include "Framework/runDataProcessing.h"
 
 #include "PWGHF/Core/SelectorCuts.h"
@@ -42,6 +43,9 @@ struct HfTaskB0 {
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_b0_to_d_pi::vecBinsPt}, "pT bin limits"};
   // MC checks
   Configurable<bool> checkDecayTypeMc{"checkDecayTypeMc", false, "Flag to enable DecayType histogram"};
+
+  // O2DatabasePDG service
+  Service<o2::framework::O2DatabasePDG> pdg;
 
   using TracksWithSel = soa::Join<aod::Tracks, aod::TrackSelection>;
 
@@ -269,7 +273,7 @@ struct HfTaskB0 {
       if (TESTBIT(std::abs(particle.flagMcMatchGen()), hf_cand_b0::DecayType::B0ToDPi)) {
 
         auto ptParticle = particle.pt();
-        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kB0));
+        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, pdg->Mass(pdg::Code::kB0));
         if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
           continue;
         }
@@ -281,7 +285,7 @@ struct HfTaskB0 {
         for (const auto& daught : particle.daughters_as<aod::McParticles>()) {
           ptProngs[counter] = daught.pt();
           etaProngs[counter] = daught.eta();
-          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
+          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, pdg->Mass(daught.pdgCode()));
           counter++;
         }
 

--- a/PWGHF/D2H/Tasks/taskBplus.cxx
+++ b/PWGHF/D2H/Tasks/taskBplus.cxx
@@ -20,6 +20,7 @@
 
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
+#include "Framework/O2DatabasePDGPlugin.h"
 #include "Framework/runDataProcessing.h"
 
 #include "PWGHF/Core/SelectorCuts.h"
@@ -51,6 +52,9 @@ struct HfTaskBplus {
   Configurable<float> etaTrackMax{"etaTrackMax", 0.8, "max. track pseudo-rapidity"};
   Configurable<float> ptTrackMin{"ptTrackMin", 0.1, "min. track transverse momentum"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_bplus_to_d0_pi::vecBinsPt}, "pT bin limits"};
+
+  // O2DatabasePDG service
+  Service<o2::framework::O2DatabasePDG> pdg;
 
   Partition<soa::Join<aod::HfCandBplus, aod::HfSelBplusToD0Pi>> selectedBPlusCandidates = aod::hf_sel_candidate_bplus::isSelBplusToD0Pi >= selectionFlagBplus;
   Partition<soa::Join<aod::HfCandBplus, aod::HfSelBplusToD0Pi, aod::HfCandBplusMcRec>> selectedBPlusCandidatesMC = aod::hf_sel_candidate_bplus::isSelBplusToD0Pi >= selectionFlagBplus;
@@ -259,7 +263,7 @@ struct HfTaskBplus {
       if (TESTBIT(std::abs(particle.flagMcMatchGen()), hf_cand_bplus::DecayType::BplusToD0Pi)) {
 
         auto ptParticle = particle.pt();
-        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kBPlus));
+        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, pdg->Mass(pdg::Code::kBPlus));
         if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
           continue;
         }
@@ -269,7 +273,7 @@ struct HfTaskBplus {
         for (const auto& daught : particle.daughters_as<aod::McParticles>()) {
           ptProngs[counter] = daught.pt();
           etaProngs[counter] = daught.eta();
-          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
+          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, pdg->Mass(daught.pdgCode()));
           counter++;
         }
 

--- a/PWGHF/D2H/Tasks/taskBplusReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskBplusReduced.cxx
@@ -157,7 +157,7 @@ struct HfTaskBplusReduced {
     return std::abs(etaProng) <= etaTrackMax && ptProng >= ptTrackMin;
   }
 
-  void process(soa::Filtered<soa::Join<aod::HfCandBplus, aod::HfSelBplusToD0Pi>> const& candidates,
+  void process(soa::Filtered<soa::Join<aod::HfRedCandBplus, aod::HfSelBplusToD0Pi>> const& candidates,
                aod::HfRed2Prongs const&,
                aod::HfRedTracks const&)
   {
@@ -198,7 +198,7 @@ struct HfTaskBplusReduced {
   }   // process
 
   /// B+ MC analysis and fill histograms
-  void processMc(soa::Join<aod::HfCandBplus, aod::HfMcRecRedBps> const& candidates,
+  void processMc(soa::Join<aod::HfRedCandBplus, aod::HfMcRecRedBps> const& candidates,
                  aod::HfMcGenRedBps const& particlesMc,
                  aod::HfRed2Prongs const&)
   {

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -718,7 +718,6 @@ DECLARE_SOA_TABLE(HfCandBplusBase, "AOD", "HFCANDBPLUSBASE",
                   hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1,
                   hf_cand::ImpactParameter0, hf_cand::ImpactParameter1,
                   hf_cand::ErrorImpactParameter0, hf_cand::ErrorImpactParameter1,
-                  hf_cand_bplus::Prong0Id, hf_track_index::Prong1Id,
                   hf_track_index::HFflag,
                   /* dynamic columns */
                   hf_cand_2prong::M<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
@@ -747,7 +746,10 @@ DECLARE_SOA_TABLE(HfCandBplusBase, "AOD", "HFCANDBPLUSBASE",
 DECLARE_SOA_EXTENDED_TABLE_USER(HfCandBplusExt, HfCandBplusBase, "HFCANDBPLUSEXT",
                                 hf_cand_2prong::Px, hf_cand_2prong::Py, hf_cand_2prong::Pz);
 
-using HfCandBplus = HfCandBplusExt;
+DECLARE_SOA_TABLE(HfCandBplusProngs, "AOD", "HFCANDBPPRONGS",
+                  hf_cand_bplus::Prong0Id, hf_track_index::Prong1Id);
+
+using HfCandBplus = soa::Join<HfCandBplusExt, HfCandBplusProngs>;
 
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfCandBplusMcRec, "AOD", "HFCANDBPMCREC",

--- a/PWGHF/DataModel/CandidateSelectionTables.h
+++ b/PWGHF/DataModel/CandidateSelectionTables.h
@@ -417,7 +417,7 @@ bool selectionTopol(const T1& candBp, const T2& cuts, const T3& binsPt)
   }
 
   // B+ mass cut
-  if (std::abs(invMassBplusToD0Pi(candBp) - RecoDecay::getMassPDG(521)) > cuts->get(pTBin, "m")) {
+  if (std::abs(o2::aod::hf_cand_bplus::invMassBplusToD0Pi(candBp) - RecoDecay::getMassPDG(521)) > cuts->get(pTBin, "m")) {
     return false;
   }
 

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -17,6 +17,7 @@
 
 #include "DCAFitter/DCAFitterN.h"
 #include "Framework/AnalysisTask.h"
+#include "Framework/O2DatabasePDGPlugin.h"
 #include "Framework/runDataProcessing.h"
 #include "ReconstructionDataFormats/DCA.h"
 #include "ReconstructionDataFormats/V0.h"
@@ -70,11 +71,21 @@ struct HfCandidateCreatorB0 {
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
   int runNumber;
 
-  double massPi = RecoDecay::getMassPDG(kPiPlus);
-  double massD = RecoDecay::getMassPDG(pdg::Code::kDMinus);
-  double massB0 = RecoDecay::getMassPDG(pdg::Code::kB0);
-  double massDPi{0.};
+  // O2DatabasePDG service
+  Service<o2::framework::O2DatabasePDG> pdg;
+
+  double massPi{0.};
+  double massD{0.};
+  double massB0{0.};
+  double invMass2DPi{0.};
+  double invMass2DPiMin{0.};
+  double invMass2DPiMax{0.};
   double bz{0.};
+
+  // Fitter for B vertex (2-prong vertex filter)
+  o2::vertexing::DCAFitterN<2> df2;
+  // Fitter to redo D-vertex to get extrapolated daughter tracks (3-prong vertex filter)
+  o2::vertexing::DCAFitterN<3> df3;
 
   using TracksWithSel = soa::Join<aod::TracksWCovDca, aod::TrackSelection>;
 
@@ -88,17 +99,43 @@ struct HfCandidateCreatorB0 {
   OutputObj<TH1F> hPtD{TH1F("hPtD", "D^{#minus} candidates;D^{#minus} candidate #it{p}_{T} (GeV/#it{c});entries", 100, 0., 10.)};
   OutputObj<TH1F> hPtPion{TH1F("hPtPion", "#pi^{#plus} candidates;#pi^{#plus} candidate #it{p}_{T} (GeV/#it{c});entries", 100, 0., 10.)};
   OutputObj<TH1F> hCPAD{TH1F("hCPAD", "D^{#minus} candidates;D^{#minus} cosine of pointing angle;entries", 110, -1.1, 1.1)};
-  OutputObj<TH1F> hMassB0ToDPi{TH1F("hMassB0ToDPi", "2-prong candidates;inv. mass (B^{0} #rightarrow D^{#minus}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#minus}#pi^{#plus}) (GeV/#it{c}^{2});entries", 500, 3., 8.)};
+  OutputObj<TH1F> hMass2B0ToDPi{TH1F("hMass2B0ToDPi", "2-prong candidates;inv. mass (B^{0} #rightarrow D^{#minus}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#minus}#pi^{#plus}) square (GeV^{2}/#it{c}^{4});entries", 500, 3., 8.)};
   OutputObj<TH1F> hCovPVXX{TH1F("hCovPVXX", "2-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", 100, 0., 1.e-4)};
   OutputObj<TH1F> hCovSVXX{TH1F("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", 100, 0., 0.2)};
 
   void init(InitContext const&)
   {
+    // Initialise fitter for B vertex (2-prong vertex filter)
+    df2.setPropagateToPCA(propagateToPCA);
+    df2.setMaxR(maxR);
+    df2.setMaxDZIni(maxDZIni);
+    df2.setMinParamChange(minParamChange);
+    df2.setMinRelChi2Change(minRelChi2Change);
+    df2.setUseAbsDCA(useAbsDCA);
+    df2.setWeightedFinalPCA(useWeightedFinalPCA);
+
+    // Initial fitter to redo D-vertex to get extrapolated daughter tracks (3-prong vertex filter)
+    df3.setPropagateToPCA(propagateToPCA);
+    df3.setMaxR(maxR);
+    df3.setMaxDZIni(maxDZIni);
+    df3.setMinParamChange(minParamChange);
+    df3.setMinRelChi2Change(minRelChi2Change);
+    df3.setUseAbsDCA(useAbsDCA);
+    df3.setWeightedFinalPCA(useWeightedFinalPCA);
+
+    // Configure CCDB access
     ccdb->setURL(ccdbUrl);
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
     lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(ccdbPathLut));
     runNumber = 0;
+
+    // invariant-mass window cut
+    massPi = pdg->Mass(kPiPlus);
+    massD = pdg->Mass(pdg::Code::kDMinus);
+    massB0 = pdg->Mass(pdg::Code::kB0);
+    invMass2DPiMin = (massB0 - invMassWindowB0) * (massB0 - invMassWindowB0);
+    invMass2DPiMax = (massB0 + invMassWindowB0) * (massB0 + invMassWindowB0);
   }
 
   /// Single-track cuts for pions on dcaXY
@@ -127,27 +164,6 @@ struct HfCandidateCreatorB0 {
                TracksWithSel const&,
                aod::BCsWithTimestamps const&)
   {
-    // Initialise fitter for B vertex (2-prong vertex filter)
-    o2::vertexing::DCAFitterN<2> df2;
-    // df2.setBz(bz);
-    df2.setPropagateToPCA(propagateToPCA);
-    df2.setMaxR(maxR);
-    df2.setMaxDZIni(maxDZIni);
-    df2.setMinParamChange(minParamChange);
-    df2.setMinRelChi2Change(minRelChi2Change);
-    df2.setUseAbsDCA(useAbsDCA);
-    df2.setWeightedFinalPCA(useWeightedFinalPCA);
-
-    // Initial fitter to redo D-vertex to get extrapolated daughter tracks (3-prong vertex filter)
-    o2::vertexing::DCAFitterN<3> df3;
-    // df3.setBz(bz);
-    df3.setPropagateToPCA(propagateToPCA);
-    df3.setMaxR(maxR);
-    df3.setMaxDZIni(maxDZIni);
-    df3.setMinParamChange(minParamChange);
-    df3.setMinRelChi2Change(minRelChi2Change);
-    df3.setUseAbsDCA(useAbsDCA);
-    df3.setWeightedFinalPCA(useWeightedFinalPCA);
 
     static int ncol = 0;
 
@@ -283,12 +299,12 @@ struct HfCandidateCreatorB0 {
           df2.getTrack(0).getPxPyPzGlo(pVecD);    // momentum of D at the B0 vertex
           df2.getTrack(1).getPxPyPzGlo(pVecPion); // momentum of Pi at the B0 vertex
 
-          // calculate invariant mass and apply selection
-          massDPi = RecoDecay::m(std::array{pVecD, pVecPion}, std::array{massD, massPi});
-          if (std::abs(massDPi - massB0) > invMassWindowB0) {
+          // calculate invariant mass square and apply selection
+          invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
+          if ((invMass2DPi < invMass2DPiMin) || (invMass2DPi > invMass2DPiMax)) {
             continue;
           }
-          hMassB0ToDPi->Fill(massDPi);
+          hMass2B0ToDPi->Fill(invMass2DPi);
 
           // compute impact parameters of D and Pi
           o2::dataformats::DCA dcaD;

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -77,7 +77,6 @@ struct HfCandidateCreatorB0 {
   double massPi{0.};
   double massD{0.};
   double massB0{0.};
-  double invMass2DPi{0.};
   double invMass2DPiMin{0.};
   double invMass2DPiMax{0.};
   double bz{0.};
@@ -99,7 +98,7 @@ struct HfCandidateCreatorB0 {
   OutputObj<TH1F> hPtD{TH1F("hPtD", "D^{#minus} candidates;D^{#minus} candidate #it{p}_{T} (GeV/#it{c});entries", 100, 0., 10.)};
   OutputObj<TH1F> hPtPion{TH1F("hPtPion", "#pi^{#plus} candidates;#pi^{#plus} candidate #it{p}_{T} (GeV/#it{c});entries", 100, 0., 10.)};
   OutputObj<TH1F> hCPAD{TH1F("hCPAD", "D^{#minus} candidates;D^{#minus} cosine of pointing angle;entries", 110, -1.1, 1.1)};
-  OutputObj<TH1F> hMass2B0ToDPi{TH1F("hMass2B0ToDPi", "2-prong candidates;inv. mass (B^{0} #rightarrow D^{#minus}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#minus}#pi^{#plus}) square (GeV^{2}/#it{c}^{4});entries", 500, 3., 8.)};
+  OutputObj<TH1F> hMassB0ToDPi{TH1F("hMassB0ToDPi", "2-prong candidates;inv. mass (B^{0} #rightarrow D^{#minus}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#minus}#pi^{#plus}) (GeV/#it{c}^{2});entries", 500, 3., 8.)};
   OutputObj<TH1F> hCovPVXX{TH1F("hCovPVXX", "2-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", 100, 0., 1.e-4)};
   OutputObj<TH1F> hCovSVXX{TH1F("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", 100, 0., 0.2)};
 
@@ -300,11 +299,11 @@ struct HfCandidateCreatorB0 {
           df2.getTrack(1).getPxPyPzGlo(pVecPion); // momentum of Pi at the B0 vertex
 
           // calculate invariant mass square and apply selection
-          invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
+          auto invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
           if ((invMass2DPi < invMass2DPiMin) || (invMass2DPi > invMass2DPiMax)) {
             continue;
           }
-          hMass2B0ToDPi->Fill(invMass2DPi);
+          hMassB0ToDPi->Fill(std::sqrt(invMass2DPi));
 
           // compute impact parameters of D and Pi
           o2::dataformats::DCA dcaD;

--- a/PWGHF/TableProducer/candidateCreatorBplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorBplus.cxx
@@ -83,7 +83,6 @@ struct HfCandidateCreatorBplus {
   double massPi{0.};
   double massD0{0.};
   double massBplus{0.};
-  double invMass2D0Pi{0.};
   double invMass2D0PiMin{0.};
   double invMass2D0PiMax{0.};
   double bz{0.};
@@ -104,7 +103,7 @@ struct HfCandidateCreatorBplus {
   OutputObj<TH1F> hCovSVXX{TH1F("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", 100, 0., 0.2)};
   OutputObj<TH1F> hRapidityD0{TH1F("hRapidityD0", "D0 candidates;#it{y};entries", 100, -2, 2)};
   OutputObj<TH1F> hEtaPi{TH1F("hEtaPi", "Pion track;#it{#eta};entries", 400, -2., 2.)};
-  OutputObj<TH1F> hMass2BplusToD0Pi{TH1F("hMass2BplusToD0Pi", "2-prong candidates;inv. mass (B^{+} #rightarrow #bar{D^{0}}#pi^{+}) square (GeV^{2}/#it{c}^{4});entries", 500, 3., 8.)};
+  OutputObj<TH1F> hMassBplusToD0Pi{TH1F("hMassBplusToD0Pi", "2-prong candidates;inv. mass (B^{+} #rightarrow #bar{D^{0}}#pi^{+}) (GeV/#it{c}^{2});entries", 500, 3., 8.)};
 
   void init(InitContext const&)
   {
@@ -315,11 +314,11 @@ struct HfCandidateCreatorBplus {
           int hfFlag = BIT(hf_cand_bplus::DecayType::BplusToD0Pi);
 
           // compute invariant mass square and apply selection
-          invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecBach}, std::array{massD0, massPi});
+          auto invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecBach}, std::array{massD0, massPi});
           if ((invMass2D0Pi < invMass2D0PiMin) || (invMass2D0Pi > invMass2D0PiMax)) {
             continue;
           }
-          hMass2BplusToD0Pi->Fill(invMass2D0Pi);
+          hMassBplusToD0Pi->Fill(std::sqrt(invMass2D0Pi));
 
           // fill candidate table rows
           rowCandidateBase(collision.globalIndex(),

--- a/PWGHF/TableProducer/candidateCreatorBplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorBplus.cxx
@@ -43,7 +43,7 @@ using namespace o2::aod::hf_cand_bplus;
 
 /// Reconstruction of B± → D0bar(D0) π± → (K± π∓) π±
 struct HfCandidateCreatorBplus {
-  Produces<aod::HfCandBplusBase> rowCandidateBase; // table defined in CandidateReconstructionTables.h
+  Produces<aod::HfCandBplusBase> rowCandidateBase;     // table defined in CandidateReconstructionTables.h
   Produces<aod::HfCandBplusProngs> rowCandidateProngs; // table defined in CandidateReconstructionTables.h
 
   // vertexing parameters

--- a/PWGHF/TableProducer/candidateCreatorBplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorBplus.cxx
@@ -20,6 +20,7 @@
 
 #include "DCAFitter/DCAFitterN.h"
 #include "Framework/AnalysisTask.h"
+#include "Framework/O2DatabasePDGPlugin.h"
 #include "Framework/runDataProcessing.h"
 #include "ReconstructionDataFormats/DCA.h"
 #include "ReconstructionDataFormats/V0.h"
@@ -42,7 +43,8 @@ using namespace o2::aod::hf_cand_bplus;
 
 /// Reconstruction of B± → D0bar(D0) π± → (K± π∓) π±
 struct HfCandidateCreatorBplus {
-  Produces<aod::HfCandBplusBase> rowCandidateBase;
+  Produces<aod::HfCandBplusBase> rowCandidateBase; // table defined in CandidateReconstructionTables.h
+  Produces<aod::HfCandBplusProngs> rowCandidateProngs; // table defined in CandidateReconstructionTables.h
 
   // vertexing parameters
   // Configurable<double> bz{"bz", 5., "magnetic field"};
@@ -75,11 +77,21 @@ struct HfCandidateCreatorBplus {
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
   int runNumber;
 
-  double massPi = RecoDecay::getMassPDG(kPiPlus);
-  double massD0 = RecoDecay::getMassPDG(pdg::Code::kD0);
-  double massBplus = RecoDecay::getMassPDG(pdg::Code::kBPlus);
-  double massD0Pi = 0.;
-  double bz = 0.;
+  // O2DatabasePDG service
+  Service<o2::framework::O2DatabasePDG> pdg;
+
+  double massPi{0.};
+  double massD0{0.};
+  double massBplus{0.};
+  double invMass2D0Pi{0.};
+  double invMass2D0PiMin{0.};
+  double invMass2D0PiMax{0.};
+  double bz{0.};
+
+  // Fitter for B vertex
+  o2::vertexing::DCAFitterN<2> dfB;
+  // Fitter to redo D-vertex to get extrapolated daughter tracks
+  o2::vertexing::DCAFitterN<2> df;
 
   using TracksWithSel = soa::Join<aod::TracksWCovDca, aod::TrackSelection>;
   using CandsDFiltered = soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfSelD0>>;
@@ -92,15 +104,39 @@ struct HfCandidateCreatorBplus {
   OutputObj<TH1F> hCovSVXX{TH1F("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", 100, 0., 0.2)};
   OutputObj<TH1F> hRapidityD0{TH1F("hRapidityD0", "D0 candidates;#it{y};entries", 100, -2, 2)};
   OutputObj<TH1F> hEtaPi{TH1F("hEtaPi", "Pion track;#it{#eta};entries", 400, -2., 2.)};
-  OutputObj<TH1F> hMassBplusToD0Pi{TH1F("hMassBplusToD0Pi", "2-prong candidates;inv. mass (B^{+} #rightarrow #bar{D^{0}}#pi^{+}) (GeV/#it{c}^{2});entries", 500, 3., 8.)};
+  OutputObj<TH1F> hMass2BplusToD0Pi{TH1F("hMass2BplusToD0Pi", "2-prong candidates;inv. mass (B^{+} #rightarrow #bar{D^{0}}#pi^{+}) square (GeV^{2}/#it{c}^{4});entries", 500, 3., 8.)};
 
   void init(InitContext const&)
   {
+    // Initialise fitter for B vertex
+    dfB.setPropagateToPCA(propagateToPCA);
+    dfB.setMaxR(maxR);
+    dfB.setMinParamChange(minParamChange);
+    dfB.setMinRelChi2Change(minRelChi2Change);
+    dfB.setUseAbsDCA(true);
+    dfB.setWeightedFinalPCA(useWeightedFinalPCA);
+
+    // Initial fitter to redo D-vertex to get extrapolated daughter tracks
+    df.setPropagateToPCA(propagateToPCA);
+    df.setMaxR(maxR);
+    df.setMinParamChange(minParamChange);
+    df.setMinRelChi2Change(minRelChi2Change);
+    df.setUseAbsDCA(useAbsDCA);
+    df.setWeightedFinalPCA(useWeightedFinalPCA);
+
+    // Configure CCDB access
     ccdb->setURL(ccdbUrl);
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
     lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(ccdbPathLut));
     runNumber = 0;
+
+    // invariant-mass window cut
+    massPi = pdg->Mass(kPiPlus);
+    massD0 = pdg->Mass(pdg::Code::kD0);
+    massBplus = pdg->Mass(pdg::Code::kBPlus);
+    invMass2D0PiMin = (massBplus - invMassWindowBplus) * (massBplus - invMassWindowBplus);
+    invMass2D0PiMax = (massBplus + invMassWindowBplus) * (massBplus + invMassWindowBplus);
   }
 
   /// Single-track cuts for pions on dcaXY
@@ -129,24 +165,6 @@ struct HfCandidateCreatorBplus {
                TracksWithSel const&,
                aod::BCsWithTimestamps const&)
   {
-
-    // Initialise fitter for B vertex
-    o2::vertexing::DCAFitterN<2> dfB;
-    dfB.setPropagateToPCA(propagateToPCA);
-    dfB.setMaxR(maxR);
-    dfB.setMinParamChange(minParamChange);
-    dfB.setMinRelChi2Change(minRelChi2Change);
-    dfB.setUseAbsDCA(true);
-    dfB.setWeightedFinalPCA(useWeightedFinalPCA);
-
-    // Initial fitter to redo D-vertex to get extrapolated daughter tracks
-    o2::vertexing::DCAFitterN<2> df;
-    df.setPropagateToPCA(propagateToPCA);
-    df.setMaxR(maxR);
-    df.setMinParamChange(minParamChange);
-    df.setMinRelChi2Change(minRelChi2Change);
-    df.setUseAbsDCA(useAbsDCA);
-    df.setWeightedFinalPCA(useWeightedFinalPCA);
 
     static int nCol = 0;
 
@@ -296,12 +314,12 @@ struct HfCandidateCreatorBplus {
 
           int hfFlag = BIT(hf_cand_bplus::DecayType::BplusToD0Pi);
 
-          // calculate invariant mass and fill the Invariant Mass control plot
-          massD0Pi = RecoDecay::m(std::array{pVecD0, pVecBach}, std::array{massD0, massPi});
-          if (std::abs(massD0Pi - massBplus) > invMassWindowBplus) {
+          // compute invariant mass square and apply selection
+          invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecBach}, std::array{massD0, massPi});
+          if ((invMass2D0Pi < invMass2D0PiMin) || (invMass2D0Pi > invMass2D0PiMax)) {
             continue;
           }
-          hMassBplusToD0Pi->Fill(massD0Pi);
+          hMass2BplusToD0Pi->Fill(invMass2D0Pi);
 
           // fill candidate table rows
           rowCandidateBase(collision.globalIndex(),
@@ -313,8 +331,9 @@ struct HfCandidateCreatorBplus {
                            pVecBach[0], pVecBach[1], pVecBach[2],
                            impactParameter0.getY(), impactParameter1.getY(),
                            std::sqrt(impactParameter0.getSigmaY2()), std::sqrt(impactParameter1.getSigmaY2()),
-                           candD0.globalIndex(), trackPion.globalIndex(), // index D0 and bachelor
                            hfFlag);
+
+          rowCandidateProngs(candD0.globalIndex(), trackPion.globalIndex()); // index D0 and bachelor
         } // track loop
       }   // D0 cand loop
     }     // collision
@@ -331,10 +350,9 @@ struct HfCandidateCreatorBplusExpressions {
 
   void processMc(aod::HfCand2Prong const& dzero,
                  aod::TracksWMc const& tracks,
-                 aod::McParticles const& particlesMC)
+                 aod::McParticles const& particlesMC,
+                 aod::HfCandBplusProngs const& candsBplus)
   {
-    rowCandidateBPlus->bindExternalIndices(&tracks);
-    rowCandidateBPlus->bindExternalIndices(&dzero);
 
     int indexRec = -1, indexRecD0 = -1;
     int8_t signB = 0, signD0 = 0;
@@ -344,12 +362,12 @@ struct HfCandidateCreatorBplusExpressions {
 
     // Match reconstructed candidates.
     // Spawned table can be used directly
-    for (const auto& candidate : *rowCandidateBPlus) {
+    for (const auto& candidate : candsBplus) {
       // Printf("New rec. candidate");
 
       flag = 0;
       origin = 0;
-      auto candDaughterD0 = candidate.prong0_as<aod::HfCand2Prong>();
+      auto candDaughterD0 = candidate.prong0();
       auto arrayDaughtersD0 = std::array{candDaughterD0.prong0_as<aod::TracksWMc>(), candDaughterD0.prong1_as<aod::TracksWMc>()};
       auto arrayDaughters = std::array{candidate.prong1_as<aod::TracksWMc>(), candDaughterD0.prong0_as<aod::TracksWMc>(), candDaughterD0.prong1_as<aod::TracksWMc>()};
 


### PR DESCRIPTION
Hello @fgrosa !

I applied the fixes to B+.

I also took the opportunity to get rid of `getMassPDG` in the standard workflows and to move the `DCAFitterN` initialisations in the `init` function (as we do for the split workflow).